### PR TITLE
Error: Failed to apply catalog: Parameter unless failed on Exec[dpkg-…

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,7 +4,7 @@
 #
 class ca_certificate::service {
 
-  exec { 'dpkg-reconfigure ca-certificates':
+  exec { '/usr/sbin/dpkg-reconfigure ca-certificates':
     unless      => '/bin/ls /etc/ssl/certs/puppet-ca.crt',
     refreshonly => true,
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@
 class ca_certificate::service {
 
   exec { 'dpkg-reconfigure ca-certificates':
-    unless      => 'ls /etc/ssl/certs/puppet-ca.crt',
+    unless      => '/bin/ls /etc/ssl/certs/puppet-ca.crt',
     refreshonly => true,
   }
 


### PR DESCRIPTION
…reconfigure ca-certificates]: 'ls /etc/ssl/certs/puppet-ca.crt' is not qualified and no path was specified. Please qualify the command or specify a path. (file: /etc/puppetlabs/code/environments/production/modules/ca_certificate/manifests/service.pp, line: 7)